### PR TITLE
Update PySquared to 25w40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYSQUARED_VERSION ?= v2.0.0-alpha-25w39
-PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)
+PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)\#subdirectory=circuitpython-workspaces/flight-software
 BOARD_MOUNT_POINT ?= ""
 BOARD_TTY_PORT ?= ""
 VERSION ?= $(shell git tag --points-at HEAD --sort=-creatordate < /dev/null | head -n 1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYSQUARED_VERSION ?= v2.0.0-alpha-25w34
+PYSQUARED_VERSION ?= v2.0.0-alpha-25w39
 PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)
 BOARD_MOUNT_POINT ?= ""
 BOARD_TTY_PORT ?= ""

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYSQUARED_VERSION ?= v2.0.0-alpha-25w39
+PYSQUARED_VERSION ?= v2.0.0-alpha-25w40
 PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)\#subdirectory=circuitpython-workspaces/flight-software
 BOARD_MOUNT_POINT ?= ""
 BOARD_TTY_PORT ?= ""

--- a/src/flight-software/main.py
+++ b/src/flight-software/main.py
@@ -121,8 +121,7 @@ try:
         uhf_packet_manager,
         boot_time,
         imu,
-        # TODO (mikefly123): add back in magnetometer once it is fixed upstream
-        # magnetometer,
+        magnetometer,
         uhf_radio,
         sband_radio,
         error_count,

--- a/src/flight-software/main.py
+++ b/src/flight-software/main.py
@@ -121,7 +121,8 @@ try:
         uhf_packet_manager,
         boot_time,
         imu,
-        magnetometer,
+        # TODO (mikefly123): add back in magnetometer once it is fixed upstream
+        # magnetometer,
         uhf_radio,
         sband_radio,
         error_count,

--- a/src/flight-software/main.py
+++ b/src/flight-software/main.py
@@ -140,7 +140,9 @@ try:
 
         cdh.listen_for_commands(10)
 
-        sleep_helper.safe_sleep(config.sleep_duration)
+        beacon.send()
+
+        cdh.listen_for_commands(config.sleep_duration)
 
     try:
         logger.info("Entering main loop")

--- a/src/flight-software/repl.py
+++ b/src/flight-software/repl.py
@@ -130,8 +130,7 @@ beacon = Beacon(
     uhf_packet_manager,
     time.monotonic(),
     imu,
-    # TODO (mikefly123): add back in magnetometer once it is fixed upstream
-    # magnetometer,
+    magnetometer,
     uhf_radio,
     sband_radio,
 )

--- a/src/flight-software/repl.py
+++ b/src/flight-software/repl.py
@@ -130,7 +130,8 @@ beacon = Beacon(
     uhf_packet_manager,
     time.monotonic(),
     imu,
-    magnetometer,
+    # TODO (mikefly123): add back in magnetometer once it is fixed upstream
+    # magnetometer,
     uhf_radio,
     sband_radio,
 )


### PR DESCRIPTION
## Summary
This update bumps the version of `pysquared` to the latest 25w39 release. 

It also removed the use of `sleep_helper` (because it's not really doing anything useful tbh) from the `main.py` loop. Instead we will be listening for commands during the time we would have originally been sleeping. This change increases the idle power consumption of the satellite, but makes it more responsive in doing so.

## How was this tested
@ineskhou if you have a chance to test this quickly on a V5b that would be greatly appreciated! 

- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
